### PR TITLE
Removed deprecated getters from bem-entity-name package

### DIFF
--- a/lib/create-stringify.js
+++ b/lib/create-stringify.js
@@ -19,11 +19,11 @@ function stringify(entity, delims) {
     }
 
     const modObj = entity.mod;
-    const modName = (typeof modObj === 'string' ? modObj : modObj && modObj.name) || entity.modName;
+    const modName = (typeof modObj === 'string' ? modObj : modObj && modObj.name);
 
     if (modName) {
-        const hasModVal = modObj && modObj.hasOwnProperty('val') || entity.hasOwnProperty('modVal');
-        const modVal = modObj && modObj.val || entity.modVal;
+        const hasModVal = modObj && modObj.hasOwnProperty('val');
+        const modVal = modObj && modObj.val;
 
         if (modVal || modVal === 0 || !hasModVal) {
             res += delims.mod.name + modName;

--- a/lib/create-stringify.js
+++ b/lib/create-stringify.js
@@ -19,11 +19,12 @@ function stringify(entity, delims) {
     }
 
     const modObj = entity.mod;
-    const modName = (typeof modObj === 'string' ? modObj : modObj && modObj.name);
+    const modName = (typeof modObj === 'string' ? modObj : modObj && modObj.name)
+        || entity.hasOwnProperty('modName') && entity.modName;
 
     if (modName) {
-        const hasModVal = modObj && modObj.hasOwnProperty('val');
-        const modVal = modObj && modObj.val;
+        const hasModVal = modObj && modObj.hasOwnProperty('val') || entity.hasOwnProperty('modVal');
+        const modVal = modObj && modObj.val || entity.modVal;
 
         if (modVal || modVal === 0 || !hasModVal) {
             res += delims.mod.name + modName;


### PR DESCRIPTION
When running `npm test` there is deprecation warning in output:

> Wed, 28 Jun 2017 11:43:06 GMT @bem/entity-name deprecated `modName` is kept just for compatibility and can be dropped in the future. Use `mod.name` instead in `BemEntityName { block: 'block' }` at at node_modules/@bem/entity-name/lib/entity-name.js:110:9

This patch removes it.